### PR TITLE
Expand "cons" abbreviation in inline documentation

### DIFF
--- a/src/main/kotlin/org/vclang/VcDocumentationProvider.kt
+++ b/src/main/kotlin/org/vclang/VcDocumentationProvider.kt
@@ -53,7 +53,7 @@ class VcDocumentationProvider : AbstractDocumentationProvider() {
         is VcDefInstance -> "instance"
         is VcClassImplement -> "implementation"
         is VcDefData -> "data"
-        is VcConstructor -> "data cons"
+        is VcConstructor -> "data constructor"
         is VcDefFunction -> "func"
         is VcLetClause -> "let"
         is VcDefIdentifier -> if (element.parent is VcLetClause) "let" else "var"


### PR DESCRIPTION
A call of inline documentation (Ctrl+Q) on the `cons` constructor will show:

![image](https://user-images.githubusercontent.com/4586392/45824370-825f6000-bcf8-11e8-8b23-588801ae8316.png)

It is better to write *data constructor*, to clarify the difference.
